### PR TITLE
Fix documentation links in sketch files

### DIFF
--- a/examples/BasicStepping/BasicStepping.ino
+++ b/examples/BasicStepping/BasicStepping.ino
@@ -7,7 +7,7 @@
 // Before using this example, be sure to change the setCurrentMilliamps36v4 line
 // to have an appropriate current limit for your system.  Also, see this
 // library's documentation for information about how to connect the driver:
-//   http://pololu.github.io/high-power-stepper-driver
+//   https://pololu.github.io/high-power-stepper-driver-arduino/
 
 #include <SPI.h>
 #include <HighPowerStepperDriver.h>

--- a/examples/BasicSteppingSPI/BasicSteppingSPI.ino
+++ b/examples/BasicSteppingSPI/BasicSteppingSPI.ino
@@ -16,7 +16,7 @@
 // Before using this example, be sure to change the setCurrentMilliamps36v4 line
 // to have an appropriate current limit for your system.  Also, see this
 // library's documentation for information about how to connect the driver:
-//   http://pololu.github.io/high-power-stepper-driver
+//   https://pololu.github.io/high-power-stepper-driver-arduino/
 
 #include <SPI.h>
 #include <HighPowerStepperDriver.h>


### PR DESCRIPTION
When I tried opening the documentation from source, I got a 404 error.